### PR TITLE
feat: transaction payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Please refer to the [usage documentation](./docs/USAGE.md) for detailed informat
 Each list below is ordered in terms of priority (higher position = higher priority).
 
 ### Features
-- `info` command (queries the node information (`api/v1/info` endpoint) of an IOTA node)
 - `monitor` command (watches a given address for updates in the IOTA ledger*)
 - `spam` command (repeatedly sends a data message to the IOTA Tangle)
 
@@ -26,7 +25,7 @@ The IOTA ledger refers to all value-based messages.
 ### Enhancements
 - Clipboard copying (IDs, messages, transactions, data, etc.)
 - Better logging and output formatting (indexation, coloring, etc.)
-- Better message formatting on `broadcast` (string-ify JSON data)
+- Better message payload formatting on `broadcast` (string-ify JSON data)
 - More arguments for commands:
     - Node authentication (username, password, and JWT)
     - Specify activity to watch for with `monitor`

--- a/src/commands/broadcast.rs
+++ b/src/commands/broadcast.rs
@@ -12,16 +12,6 @@ pub const MAX_INDEX_BYTES: usize = 64;
 /// The maximum number of bytes allowed for a data message's payload.
 pub const MAX_DATA_BYTES: usize = 4096;
 
-fn try_data_index_from_str(arg: &str) -> Result<String> {
-    let index = arg.to_string();
-    let size = index.as_bytes().len();
-
-    match size {
-        s if s < MAX_INDEX_BYTES => Ok(index),
-        _ => Err(Error::MessageDataIndexTooLarge(size)),
-    }
-}
-
 fn try_data_from_str(arg: &str) -> Result<String> {
     let data = arg.to_string();
     let size = data.as_bytes().len();
@@ -32,16 +22,26 @@ fn try_data_from_str(arg: &str) -> Result<String> {
     }
 }
 
+fn try_data_index_from_str(arg: &str) -> Result<String> {
+    let index = arg.to_string();
+    let size = index.as_bytes().len();
+
+    match size {
+        s if s < MAX_INDEX_BYTES => Ok(index),
+        _ => Err(Error::MessageDataIndexTooLarge(size)),
+    }
+}
+
 /// Arguments for the `broadcast` subcommand.
 #[derive(Debug, structopt::StructOpt)]
 pub struct BroadcastArgs {
-    /// Indexation key used in the IOTA Tangle.
-    #[structopt(parse(try_from_str=try_data_index_from_str))]
-    pub index: Option<String>,
-
     /// UTF-8 encoded data embedded inside the indexation payload.
     #[structopt(parse(try_from_str=try_data_from_str))]
     pub data: Option<String>,
+
+    /// Indexation key used in the IOTA Tangle.
+    #[structopt(parse(try_from_str=try_data_index_from_str))]
+    pub index: Option<String>,
 }
 
 impl BroadcastArgs {

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,4 +63,8 @@ pub enum Error {
     /// The payload type of the message is wrong.
     #[error("The message's payload type is wrong (should be Indexation)")]
     MessageWrongPayload,
+
+    /// The transaction essence is invalid.
+    #[error("The message's transaction essence is invalid")]
+    MessageEssenceInvalid,
 }

--- a/src/iota/client.rs
+++ b/src/iota/client.rs
@@ -64,13 +64,6 @@ pub struct ClientArgs {
 }
 
 impl ClientArgs {
-    pub fn unpack_network(&self) -> &Network {
-        match self.network {
-            Some(ref n) => n,
-            None => &Network::ChrysalisDevnet,
-        }
-    }
-
     pub fn unpack_url(&self) -> &str {
         match self.url {
             Some(ref u) => {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -38,12 +38,12 @@ For more information try --help
 
 const BASE_BROADCAST_OUTPUT: &str = "Index: tio-cli
 Data: tio-message
-Size: 11 byte(s)
+Size: 18 byte(s)
 ";
 
 const OTHER_BROADCAST_OUTPUT: &str = "Index: tio-cli-test
 Data: tio-message-test
-Size: 16 byte(s)
+Size: 28 byte(s)
 ";
 
 const BASE_SEARCH_OUTPUT: &str = BASE_BROADCAST_OUTPUT;
@@ -80,7 +80,7 @@ mod integration {
     #[test]
     fn test_call_broadcast_with_args() {
         let output = Command::new("./target/release/tio")
-            .args(["broadcast", "tio-cli-test", "tio-message-test"])
+            .args(["broadcast", "tio-message-test", "tio-cli-test"])
             .output()
             .expect("failed to broadcast message");
         assert!(String::from_utf8_lossy(&output.stdout).contains(OTHER_BROADCAST_OUTPUT))


### PR DESCRIPTION
## Overview
Adds support for `search`-ing UTXO-based payloads (including embedded data payloads). It does not support `SignatureLockedDustAllowance` outputs (soon-to-be deprecated in the protocol) nor `TreasuryInput` as an input type. 

## Changes
- Adds console output for transaction payloads (inputs and outputs __only__)
- Changes integration tests for new changes

## Notes
_None_